### PR TITLE
Avoid to create empty directory on current

### DIFF
--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -73,7 +73,7 @@ let s:delve_instructions = []
 if has('nvim')
     call mkdir(g:delve_cache_path, "p")
 else
-    silent !mkdir -p g:delve_cache_path > /dev/null 2>&1
+    silent exec "!mkdir -p " . g:delve_cache_path
 endif
 
 " Remove the instructions file


### PR DESCRIPTION
Actually, on vim,  an empty directory with name `g:delve_cache_path` is created.This PR is to avoid this behaviour.

![image](https://user-images.githubusercontent.com/3127847/28151146-4662ad8a-676f-11e7-89f9-6ba20a15b0f7.png)
