### PR TITLE
Introduce custom flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ Then reload neovim and run `PlugInstall`.
 Commands
 --------
 
-| Command                 | Comment
-|-------------------------|-----------------------------------------------------------------------------------
-| `DlvAddBreakpoint`      | Add a breakpoint at the current line.
-| `DlvAddTracepoint`      | Add a tracepoint at the current line.
-| `DlvAttach <pid>`       | Attach `dlv` to a running process.
-| `DlvClearAll`           | Clear all the breakpoints and tracepoints in the buffer.
-| `DlvDebug`              | Run `dlv debug` for the current session. Use this to test `main` packages.
-| `DlvExec <bin> <flags>` | Start `dlv` on a prebuilt executable.
-| `DlvRemoveBreakpoint`   | Remove the breakpoint at the current line.
-| `DlvRemoveTracepoint`   | Remove the tracepoint at the current line.
-| `DlvTest`               | Run `dlv test` for the current session. Use this to debug non-`main` packages.
-| `DlvToggleBreakpoint`   | Convenience method to toggle (add or remove) a breakpoint at the current line.
-| `DlvToggleTracepoint`   | Convenience method to toggle (add or remove) a tracepoint at the current line.
+| Command                   | Comment
+|---------------------------|-----------------------------------------------------------------------------------
+| `DlvAddBreakpoint`        | Add a breakpoint at the current line.
+| `DlvAddTracepoint`        | Add a tracepoint at the current line.
+| `DlvAttach <pid> [flags]` | Attach `dlv` to a running process.
+| `DlvClearAll`             | Clear all the breakpoints and tracepoints in the buffer.
+| `DlvDebug [flags]`        | Run `dlv debug` for the current session. Use this to test `main` packages.
+| `DlvExec <bin> [flags]`   | Start `dlv` on a pre-built executable.
+| `DlvRemoveBreakpoint`     | Remove the breakpoint at the current line.
+| `DlvRemoveTracepoint`     | Remove the tracepoint at the current line.
+| `DlvTest [flags]`         | Run `dlv test` for the current session. Use this to debug non-`main` packages.
+| `DlvToggleBreakpoint`     | Convenience method to toggle (add or remove) a breakpoint at the current line.
+| `DlvToggleTracepoint`     | Convenience method to toggle (add or remove) a tracepoint at the current line.
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -45,18 +45,19 @@ Then reload neovim and run `PlugInstall`.
 Commands
 --------
 
-| Command               | Comment
-|-----------------------|-----------------------------------------------------------------------------------
-| `DlvAddBreakpoint`    | Add a breakpoint at the current line.
-| `DlvAddTracepoint`    | Add a tracepoint at the current line.
-| `DlvAttach <pid>`     | Attach `dlv` to a running process.
-| `DlvClearAll`         | Clear all the breakpoints and tracepoints in the buffer.
-| `DlvDebug`            | Run `dlv debug` for the current session. Use this to test `main` packages.
-| `DlvRemoveBreakpoint` | Remove the breakpoint at the current line.
-| `DlvRemoveTracepoint` | Remove the tracepoint at the current line.
-| `DlvTest`             | Run `dlv test` for the current session. Use this to debug non-`main` packages.
-| `DlvToggleBreakpoint` | Convenience method to toggle (add or remove) a breakpoint at the current line.
-| `DlvToggleTracepoint` | Convenience method to toggle (add or remove) a tracepoint at the current line.
+| Command                 | Comment
+|-------------------------|-----------------------------------------------------------------------------------
+| `DlvAddBreakpoint`      | Add a breakpoint at the current line.
+| `DlvAddTracepoint`      | Add a tracepoint at the current line.
+| `DlvAttach <pid>`       | Attach `dlv` to a running process.
+| `DlvClearAll`           | Clear all the breakpoints and tracepoints in the buffer.
+| `DlvDebug`              | Run `dlv debug` for the current session. Use this to test `main` packages.
+| `DlvExec <bin> <flags>` | Start `dlv` on a prebuilt executable.
+| `DlvRemoveBreakpoint`   | Remove the breakpoint at the current line.
+| `DlvRemoveTracepoint`   | Remove the tracepoint at the current line.
+| `DlvTest`               | Run `dlv test` for the current session. Use this to debug non-`main` packages.
+| `DlvToggleBreakpoint`   | Convenience method to toggle (add or remove) a breakpoint at the current line.
+| `DlvToggleTracepoint`   | Convenience method to toggle (add or remove) a tracepoint at the current line.
 
 Configuration
 -------------

--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -84,7 +84,7 @@ exe "sign define delve_breakpoint text=". g:delve_breakpoint_sign ." texthl=". g
 exe "sign define delve_tracepoint text=". g:delve_tracepoint_sign ." texthl=". g:delve_tracepoint_sign_highlight
 
 " attach is attaching dlv to a running process.
-function! delve#attach(dir, pid)
+function! delve#attach(pid)
     call delve#runCommand("attach ". a:pid, "", ".", 0, 0)
 endfunction
 

--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -83,11 +83,6 @@ autocmd VimLeave * call delve#removeInstructionsFile()<cr>
 exe "sign define delve_breakpoint text=". g:delve_breakpoint_sign ." texthl=". g:delve_breakpoint_sign_highlight
 exe "sign define delve_tracepoint text=". g:delve_tracepoint_sign ." texthl=". g:delve_tracepoint_sign_highlight
 
-" attach is attaching dlv to a running process.
-function! delve#attach(pid)
-    call delve#runCommand("attach ". a:pid, "", ".", 0, 0)
-endfunction
-
 " clearAll is removing all active breakpoints and tracepoints.
 function! delve#clearAll()
     call delve#removeInstructionsFile()
@@ -96,6 +91,11 @@ function! delve#clearAll()
         let s:delve_instructions = []
         exe "sign unplace ". eval(i+1)
     endfor
+endfunction
+
+" dlvAttach is attaching dlv to a running process.
+function! delve#dlvAttach(pid)
+    call delve#runCommand("attach ". a:pid, "", ".", 0, 0)
 endfunction
 
 " dlvDebug is calling 'dlv debug' for the currently active main package.
@@ -108,8 +108,8 @@ function! delve#dlvTest(dir)
     call delve#runCommand("test", "", a:dir)
 endfunction
 
-" exec is calling dlv exec.
-function! delve#exec(bin, ...)
+" dlvExec is calling dlv exec.
+function! delve#dlvExec(bin, ...)
     let dir = (a:0 > 0) ? a:1 : "."
     let flags = (a:0 > 1) ? a:2 : ""
     call delve#runCommand("exec ". a:bin, flags, dir)
@@ -277,8 +277,8 @@ endfunction
 "-------------------------------------------------------------------------------
 command! -nargs=0 DlvAddBreakpoint call delve#addBreakpoint(expand('%:p'), line('.'))
 command! -nargs=0 DlvAddTracepoint call delve#addTracepoint(expand('%:p'), line('.'))
-command! -nargs=+ DlvAttach call delve#attach(<f-args>)
-command! -nargs=+ DlvExec call delve#exec(<f-args>)
+command! -nargs=+ DlvAttach call delve#dlvAttach(<f-args>)
+command! -nargs=+ DlvExec call delve#dlvExec(<f-args>)
 command! -nargs=0 DlvClearAll call delve#clearAll()
 command! -nargs=0 DlvDebug call delve#dlvDebug(expand('%:p:h'))
 command! -nargs=0 DlvRemoveBreakpoint call delve#removeBreakpoint(expand('%:p'), line('.'))

--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -94,18 +94,30 @@ function! delve#clearAll()
 endfunction
 
 " dlvAttach is attaching dlv to a running process.
-function! delve#dlvAttach(pid)
-    call delve#runCommand("attach ". a:pid, "", ".", 0, 0)
+function! delve#dlvAttach(pid, ...)
+    let flags = (a:0 > 0) ? a:1 : ""
+
+    call delve#runCommand("attach ". a:pid, flags, ".", 0, 0)
 endfunction
 
 " dlvDebug is calling 'dlv debug' for the currently active main package.
-function! delve#dlvDebug(dir)
-    call delve#runCommand("debug", "", a:dir)
+"
+" Optional arguments:
+" flags:        flags takes custom flags to pass to dlv.
+function! delve#dlvDebug(dir, ...)
+    let flags = (a:0 > 0) ? a:1 : ""
+
+    call delve#runCommand("debug", flags, a:dir)
 endfunction
 
 " dlvTest is calling 'dlv test' for the currently active package.
-function! delve#dlvTest(dir)
-    call delve#runCommand("test", "", a:dir)
+"
+" Optional arguments:
+" flags:        flags takes custom flags to pass to dlv.
+function! delve#dlvTest(dir, ...)
+    let flags = (a:0 > 0) ? a:1 : ""
+
+    call delve#runCommand("test", flags, a:dir)
 endfunction
 
 " dlvExec is calling dlv exec.


### PR DESCRIPTION
This makes it possible to send any command line flags to the following `dlv`
commands:

- attach
- debug
- test

Closes #14