### PR TITLE
Add dlv core support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,20 @@ Then reload neovim and run `PlugInstall`.
 Commands
 --------
 
-| Command                   | Comment
-|---------------------------|-----------------------------------------------------------------------------------
-| `DlvAddBreakpoint`        | Add a breakpoint at the current line.
-| `DlvAddTracepoint`        | Add a tracepoint at the current line.
-| `DlvAttach <pid> [flags]` | Attach `dlv` to a running process.
-| `DlvClearAll`             | Clear all the breakpoints and tracepoints in the buffer.
-| `DlvDebug [flags]`        | Run `dlv debug` for the current session. Use this to test `main` packages.
-| `DlvExec <bin> [flags]`   | Start `dlv` on a pre-built executable.
-| `DlvRemoveBreakpoint`     | Remove the breakpoint at the current line.
-| `DlvRemoveTracepoint`     | Remove the tracepoint at the current line.
-| `DlvTest [flags]`         | Run `dlv test` for the current session. Use this to debug non-`main` packages.
-| `DlvToggleBreakpoint`     | Convenience method to toggle (add or remove) a breakpoint at the current line.
-| `DlvToggleTracepoint`     | Convenience method to toggle (add or remove) a tracepoint at the current line.
+| Command                        | Comment
+|--------------------------------|-----------------------------------------------------------------------------------
+| `DlvAddBreakpoint`             | Add a breakpoint at the current line.
+| `DlvAddTracepoint`             | Add a tracepoint at the current line.
+| `DlvAttach <pid> [flags]`      | Attach `dlv` to a running process.
+| `DlvClearAll`                  | Clear all the breakpoints and tracepoints in the buffer.
+| `DlvCore <bin> <dump> [flags]` | Debug core dumps using `dlv core`.
+| `DlvDebug [flags]`             | Run `dlv debug` for the current session. Use this to test `main` packages.
+| `DlvExec <bin> [flags]`        | Start `dlv` on a pre-built executable.
+| `DlvRemoveBreakpoint`          | Remove the breakpoint at the current line.
+| `DlvRemoveTracepoint`          | Remove the tracepoint at the current line.
+| `DlvTest [flags]`              | Run `dlv test` for the current session. Use this to debug non-`main` packages.
+| `DlvToggleBreakpoint`          | Convenience method to toggle (add or remove) a breakpoint at the current line.
+| `DlvToggleTracepoint`          | Convenience method to toggle (add or remove) a tracepoint at the current line.
 
 Configuration
 -------------

--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -120,11 +120,10 @@ function! delve#dlvTest(dir, ...)
     call delve#runCommand("test", flags, a:dir)
 endfunction
 
-" dlvExec is calling dlv exec.
-function! delve#dlvExec(bin, ...)
-    let dir = (a:0 > 0) ? a:1 : "."
-    let flags = (a:0 > 1) ? a:2 : ""
-    call delve#runCommand("exec ". a:bin, flags, dir)
+" dlvCore is calling dlv core.
+function! delve#dlvCore(bin, dump, ...)
+    let flags = (a:0 > 0) ? a:1 : ""
+    call delve#runCommand("core ". a:bin ." ". a:dump, flags)
 endfunction
 
 " addBreakpoint adds a new breakpoint to the instructions and gutter. If a
@@ -290,9 +289,10 @@ endfunction
 command! -nargs=0 DlvAddBreakpoint call delve#addBreakpoint(expand('%:p'), line('.'))
 command! -nargs=0 DlvAddTracepoint call delve#addTracepoint(expand('%:p'), line('.'))
 command! -nargs=+ DlvAttach call delve#dlvAttach(<f-args>)
-command! -nargs=+ DlvExec call delve#dlvExec(<f-args>)
 command! -nargs=0 DlvClearAll call delve#clearAll()
+command! -nargs=+ DlvCore call delve#dlvCore(<f-args>)
 command! -nargs=0 DlvDebug call delve#dlvDebug(expand('%:p:h'))
+command! -nargs=+ DlvExec call delve#dlvExec(<f-args>)
 command! -nargs=0 DlvRemoveBreakpoint call delve#removeBreakpoint(expand('%:p'), line('.'))
 command! -nargs=0 DlvRemoveTracepoint call delve#removeTracepoint(expand('%:p'), line('.'))
 command! -nargs=0 DlvTest call delve#dlvTest(expand('%:p:h'))


### PR DESCRIPTION
This introduces the `dlv core` command support for vim-delve.

Closes #11