### PR TITLE
Add connect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Commands
 | `DlvAttach <pid> [flags]`      | Attach `dlv` to a running process.
 | `DlvClearAll`                  | Clear all the breakpoints and tracepoints in the buffer.
 | `DlvCore <bin> <dump> [flags]` | Debug core dumps using `dlv core`.
+| `DlvConnect host:port [flags]` | Connect to a remote Delve server on the given host:port.
 | `DlvDebug [flags]`             | Run `dlv debug` for the current session. Use this to test `main` packages.
 | `DlvExec <bin> [flags]`        | Start `dlv` on a pre-built executable.
 | `DlvRemoveBreakpoint`          | Remove the breakpoint at the current line.

--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -135,6 +135,17 @@ function! delve#dlvAttach(pid, ...)
     call delve#runCommand("attach ". a:pid, flags, ".", 0, 0)
 endfunction
 
+" dlvConnect is calling dlv connect.
+"
+" Optional arguments:
+" address:      host:port to connect to.
+" flags:        flags takes custom flags to pass to dlv.
+function! delve#dlvConnect(address, ...)
+    let flags = (a:0 > 0) ? a:1 : ""
+
+    call delve#runCommand("connect ". a:address, flags)
+endfunction
+
 " dlvCore is calling dlv core.
 function! delve#dlvCore(bin, dump, ...)
     let flags = (a:0 > 0) ? a:1 : ""
@@ -311,6 +322,7 @@ command! -nargs=0 DlvAddTracepoint call delve#addTracepoint(expand('%:p'), line(
 command! -nargs=+ DlvAttach call delve#dlvAttach(<f-args>)
 command! -nargs=0 DlvClearAll call delve#clearAll()
 command! -nargs=+ DlvCore call delve#dlvCore(<f-args>)
+command! -nargs=+ DlvConnect call delve#dlvConnect(<f-args>)
 command! -nargs=* DlvDebug call delve#dlvDebug(expand('%:p:h'), <f-args>)
 command! -nargs=+ DlvExec call delve#dlvExec(<f-args>)
 command! -nargs=0 DlvRemoveBreakpoint call delve#removeBreakpoint(expand('%:p'), line('.'))


### PR DESCRIPTION
This command now implements `dlv connect` support, so that it's possible to
connect to a remote Delve server. It takse the host and port as input.

Closes #10