### PR TITLE
Avoid black screen after :silent !command

### DIFF
--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -73,7 +73,8 @@ let s:delve_instructions = []
 if has('nvim')
     call mkdir(g:delve_cache_path, "p")
 else
-    silent exec "!mkdir -p " . g:delve_cache_path
+    let command = "mkdir -p " . g:delve_cache_path . " > /dev/null 2>&1"
+    silent call system(command)
 endif
 
 " Remove the instructions file


### PR DESCRIPTION
According to `:help :silent`
```
":silent" will also avoid the hit-enter prompt.  When
using this for an external command, this may cause the
screen to be messed up.  Use |CTRL-L| to clean it up
then.
```
When you run `:silent !ls` for example, vim becomes black.
Vim continues to function normally, but there is black screen without displaying anything.
thus you have to refresh the screen manually.

This PR is to avoid black screen.