### PR TITLE
Add support for using benmills/vimux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Feature highlights
 - Launches a Delve CLI, so all commands are supported in there
 - Leverages the Neovim terminal (only on Neovim)
 - Supports `main` as well as and non-`main` packages
+- Supports [vimux](https://github.com/benmills/vimux) optionally
 
 ![animated example](https://github.com/sebdah/vim-delve/raw/master/vim-delve-demo.gif "vim-delve demo")
 
@@ -31,6 +32,10 @@ If you are on vim (not neovim), you'll also need the following two packages:
 
 - [Shougo/vimshell.vim](https://github.com/Shougo/vimshell.vim)
 - [Shougo/vimproc.vim](https://github.com/Shougo/vimproc.vim)
+
+If you wish to use vimux:
+
+- [benmills/vimux](https://github.com/benmills/vimux)
 
 Installation
 ------------
@@ -75,6 +80,7 @@ Configuration
 | `g:delve_new_command`                | `vnew`                                           | Control if `dlv` should be opened in a vertical (`vnew`), horizontal (`new`) or full screen window (`enew`).
 | `g:delve_tracepoint_sign_highlight`  | `WarningMsg`                                     | Set the color profile for the sign.
 | `g:delve_tracepoint_sign`            | `◆`                                              | Sets the sign to use to indicate tracepoints in the gutter.
+| `g:delve_use_vimux      `            | `0`                                              | Sets whether to use [benmills/vimux](https://github.com/benmills/vimux)].
 
 The settings above can be set in your `init.vim` like this:
 


### PR DESCRIPTION
# What
Add a global config option for enabling sending dlv commands to a nearby
tmux pane using benmills/vimux, instead of sending commands to a
terminal buffer within vim.

# Why
For those of us with a workflow where we run tests outside of vim using
vimux and other plugins like vim-test, it better integrates delve more
seamlessly. Instead of running tests in an adjacent tmux pane, then
running delve inside vim, both can be run in an adjacent tmux pane.

# Notes
The changes also include:

1. Not setting the `--backend` parameter if it's value is `default`.
Normally users of this plugin do not see the command that is executed,
but when using vimux they do. It's unnecessary to set the value of that
parameter with default as that is the default value if not set, so it
reduces the length of the command.

2. Adding a `cd -` to the end, since a tmux pane will be reused and it's
nice if changing the directory if we return the user to their original
directory.