### PR TITLE
Add function to get init instructions to support vim-test

### DIFF
--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -322,6 +322,10 @@ function! delve#writeInstructionsFile()
     call writefile(s:delve_instructions + ["continue"], g:delve_instructions_file)
 endfunction
 
+function! delve#getInitInstructions()
+    return s:delve_instructions
+endfunction
+
 "-------------------------------------------------------------------------------
 "                                 Commands
 "-------------------------------------------------------------------------------


### PR DESCRIPTION
# What
Add function to get init instructions.

# Why
The init instructions that the vim-delve plugin builds up that contains
breakpoints, tracepoints, etc are useful to other plugins, but they are
inaccessible because they are store in a script-scoped variable. Adding
this function to expose the instructions allows other plugins to tap
into the breakpoints, tracepoints, etc that the vim-delve plugin are
tracking for the user. I'm planning on using the instructions in another
plugin that's a work-in-progress.