### PR TITLE
Add `g:delve_instructions_file` as an config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,19 @@ Commands
 Configuration
 -------------
 
-| Setting                              | Default value                                    | Comment
-|--------------------------------------|--------------------------------------------------|-----------------------
-| `g:delve_backend`                    | `default`                                        | Defines the backend to use with Delve. Please refer to the [Delve documentation](https://github.com/derekparker/delve/blob/master/Documentation/usage/dlv.md#options) for details on what you should set this value to.
-| `g:delve_breakpoint_sign_highlight`  | `WarningMsg`                                     | Set the color profile for the sign.
-| `g:delve_breakpoint_sign`            | `●`                                              | Sets the sign to use to indicate breakpoints in the gutter.
-| `g:delve_cache_path`                 | `$HOME . "/.cache/" . v:progname . "/vim-delve"` | The path to where the instructions file for `dlv` is stored.
-| `g:delve_enable_syntax_highlighting` | `1`                                              | Turn syntax highlighting in the `dlv` output on or off.
-| `g:delve_new_command`                | `vnew`                                           | Control if `dlv` should be opened in a vertical (`vnew`), horizontal (`new`) or full screen window (`enew`).
-| `g:delve_tracepoint_sign_highlight`  | `WarningMsg`                                     | Set the color profile for the sign.
-| `g:delve_tracepoint_sign`            | `◆`                                              | Sets the sign to use to indicate tracepoints in the gutter.
-| `g:delve_use_vimux      `            | `0`                                              | Sets whether to use [benmills/vimux](https://github.com/benmills/vimux)].
-| `g:delve_project_root`               |                                                  | Override the path to use for setting breakpoints/tracepoints.
+| Setting                              | Default value                                         | Comment
+|--------------------------------------|-------------------------------------------------------|-----------------------
+| `g:delve_backend`                    | `default`                                             | Defines the backend to use with Delve. Please refer to the [Delve documentation](https://github.com/derekparker/delve/blob/master/Documentation/usage/dlv.md#options) for details on what you should set this value to.
+| `g:delve_breakpoint_sign_highlight`  | `WarningMsg`                                          | Set the color profile for the sign.
+| `g:delve_breakpoint_sign`            | `●`                                                   | Sets the sign to use to indicate breakpoints in the gutter.
+| `g:delve_cache_path`                 | `$HOME . "/.cache/" . v:progname . "/vim-delve"`      | The path to where the instructions file for `dlv` is stored.
+| `g:delve_instructions_file`          | `g:delve_cache_path ."/". getpid() .".". localtime()` | The instructions file name.
+| `g:delve_enable_syntax_highlighting` | `1`                                                   | Turn syntax highlighting in the `dlv` output on or off.
+| `g:delve_new_command`                | `vnew`                                                | Control if `dlv` should be opened in a vertical (`vnew`), horizontal (`new`) or full screen window (`enew`).
+| `g:delve_tracepoint_sign_highlight`  | `WarningMsg`                                          | Set the color profile for the sign.
+| `g:delve_tracepoint_sign`            | `◆`                                                   | Sets the sign to use to indicate tracepoints in the gutter.
+| `g:delve_use_vimux      `            | `0`                                                   | Sets whether to use [benmills/vimux](https://github.com/benmills/vimux)].
+| `g:delve_project_root`               |                                                       | Override the path to use for setting breakpoints/tracepoints.
 
 The settings above can be set in your `init.vim` like this:
 

--- a/plugin/delve.vim
+++ b/plugin/delve.vim
@@ -64,7 +64,9 @@ endif
 
 " g:delve_instructions_file holdes the path to the instructions file. It should
 " be reasonably unique.
-let g:delve_instructions_file = g:delve_cache_path ."/". getpid() .".". localtime()
+if !exists("g:delve_instructions_file")
+    let g:delve_instructions_file = g:delve_cache_path ."/". getpid() .".". localtime()
+endif
 
 " g:delve_use_vimux is setting whether to use vimux to run the dlv command
 " in an adjacent tmux pane instead of inside vim.


### PR DESCRIPTION
I want to manually start dlv in terminal.
For this I need to know where the instructions file.

I wrote a small function that saves dlv.init to the root of the project.
`~/.vimrc`:
```vim
function! SaveDlvInit()
    let instructions = delve#getInitInstructions()
    if len(instructions) > 0
        let root = trim(system("dirname $(go env GOMOD)"))
        let g:delve_instructions_file = root."/"."dlv.init"
        call delve#writeInstructionsFile()
    else
        call delve#removeInstructionsFile()
    endif
endfunction

autocmd FileType go autocmd BufWritePost * call SaveDlvInit()
```