### PR TITLE
feat: add test support and enhance delve plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/test/profile.txt
+/test/.coverage_covimerage

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+default: test
+
+.PHONY: test
+test:
+	cd test; PROFILE_LOG=profile.txt themis --reporter dot *.vimspec
+
+.PHONY: gen-coverage
+gen-coverage:
+	cd test; covimerage write_coverage profile.txt
+
+cover: test gen-coverage
+	cd test; coverage report

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+plugins = covimerage
+data_file = .coverage_covimerage

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -1,0 +1,13 @@
+let g:repo_root = fnamemodify(expand('<sfile>'), ':h:h')
+
+call themis#option('exclude', g:repo_root . '/test/.coveragerc')
+call themis#helper('command').with(themis#helper('assert'))
+
+if $PROFILE_LOG !=# ''
+    execute 'profile' 'start' $PROFILE_LOG
+    execute 'profile!' 'file' g:repo_root . '/plugin/delve.vim'
+endif
+
+call themis#option('runtimepath', expand(g:repo_root))
+
+syntax on

--- a/test/test.vimspec
+++ b/test/test.vimspec
@@ -1,0 +1,276 @@
+Describe s:construct_current_unique_testname
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+
+        new testdata/sample_test.go
+    End
+
+    After
+        close!
+    End
+
+    It returns test name for table test
+        normal! 20G
+        let want = 'TestWithSliceTableTest/ok$'
+        let got = s:funcs.construct_current_unique_testname()
+        Assert Equals(got, want)
+    End
+    It returns test name for table test when it is in t.Run() scope
+        normal! 25G
+        let want = 'TestWithSliceTableTest/success$'
+        let got = s:funcs.construct_current_unique_testname()
+        Assert Equals(got, want)
+    End
+    It returns test name for direct test
+        normal! 46G
+        let want = 'TestWithDirectSubtest/ok$'
+        let got = s:funcs.construct_current_unique_testname()
+        Assert Equals(got, want)
+    End
+    It returns test name for direct test when it is second test case
+        normal! 56G
+        let want = 'TestWithDirectSubtest/success$'
+        let got = s:funcs.construct_current_unique_testname()
+        Assert Equals(got, want)
+    End
+End
+
+Describe s:scan_function_name
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+    End
+
+    After
+    End
+
+    It returns test name only
+        let arg = 'func TestWithDirectSubtest(t *testing.T) {'
+        let want = 'TestWithDirectSubtest'
+        let got = s:funcs.scan_function_name(arg)
+        Assert Equals(got, want)
+    End
+End
+
+Describe s:scan_subtest_name_for_tabletest
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+    End
+
+    After
+    End
+
+    It returns subtest name
+        let arg = '			name: "ok",'
+        let want = 'ok$'
+        let got = s:funcs.scan_subtest_name_for_tabletest(arg)
+        Assert Equals(got, want)
+    End
+    It returns subtest name contains space
+        let arg = '			name: "ok. the name contains space",'
+        let want = 'ok._the_name_contains_space$'
+        let got = s:funcs.scan_subtest_name_for_tabletest(arg)
+        Assert Equals(got, want)
+    End
+    It returns subtest name contains parentheses
+        let arg = '			name: "fail. getName() returns error"'
+        let want = 'fail._getName.._returns_error$'
+        let got = s:funcs.scan_subtest_name_for_tabletest(arg)
+        Assert Equals(got, want)
+    End
+End
+
+
+Describe s:scan_subtest_name_for_direct_definition
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+    End
+
+    After
+    End
+
+    It returns subtest name
+        let arg = '	t.Run("ok", func(t *testing.T) {'
+        let want = 'ok$'
+        let got = s:funcs.scan_subtest_name_for_direct_definition(arg)
+        Assert Equals(got, want)
+    End
+    It returns subtest name contains space
+        let arg = '	t.Run("ok. the name contains space", func(t *testing.T) {'
+        let want = 'ok._the_name_contains_space$'
+        let got = s:funcs.scan_subtest_name_for_direct_definition(arg)
+        Assert Equals(got, want)
+    End
+    It returns subtest name contains parentheses
+        let arg = '	t.Run("fail. getName() returns error", func(t *testing.T) {'
+        let want = 'fail._getName.._returns_error$'
+        let got = s:funcs.scan_subtest_name_for_direct_definition(arg)
+        Assert Equals(got, want)
+    End
+End
+
+Describe s:detect_subtest_format_type
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+    End
+
+    After
+    End
+
+    It detect format type slice when it is target test case
+        new testdata/sample_test.go
+        normal! 19G
+
+        let want = 1
+        let got = s:funcs.detect_subtest_format_type()
+        Assert Equals(got, want)
+        close!
+    End
+    It detect format type slice when it is in r.Run() scope
+        new testdata/sample_test.go
+        normal! 25G
+
+        let want = 1
+        let got = s:funcs.detect_subtest_format_type()
+        Assert Equals(got, want)
+        close!
+    End
+    It detect format type undetected when it is out of appropriate scope
+        new testdata/sample_test.go
+        normal! 9G
+
+        let want = 0
+        let got = s:funcs.detect_subtest_format_type()
+        Assert Equals(got, want)
+        close!
+    End
+    It detect format type direct when it is in t.Run() scope
+        new testdata/sample_test.go
+        normal! 45G
+
+        let want = 2
+        let got = s:funcs.detect_subtest_format_type()
+        Assert Equals(got, want)
+        close!
+    End
+    It detect format type undetected when it is out of t.Run() scope
+        new testdata/sample_test.go
+        normal! 11G
+
+        let want = 0
+        let got = s:funcs.detect_subtest_format_type()
+        Assert Equals(got, want)
+        close!
+    End
+    It detect format type undetected when it is out of function
+        new testdata/sample_test.go
+        normal! 4G
+
+        let want = 0
+        let got = s:funcs.detect_subtest_format_type()
+        Assert Equals(got, want)
+        close!
+    End
+End
+
+Describe s:detect_subtest_format_type for preparations
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+    End
+
+    After
+    End
+
+    It search for query func Test
+        new testdata/sample_test.go
+        normal! 13G
+        let got = search("func Test", "bcnW")
+        let want = 9
+        Assert Equals(got, want)
+        close!
+    End
+    It search for query name
+        new testdata/sample_test.go
+        normal! 20G
+        let got = search("name: ", "bcnW")
+        let want = 17
+        Assert Equals(got, want)
+        close!
+    End
+    It search for query t.Run
+        new testdata/sample_test.go
+        normal! 47G
+        let got = search('t.Run("', "bcnW")
+        let want = 42
+        Assert Equals(got, want)
+        close!
+    End
+End
+
+Describe s:construct_function_unique_testname
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+
+        new testdata/sample_test.go
+    End
+
+    After
+        close!
+    End
+
+    It returns test name for function
+        normal! 22G
+        let want = 'TestWithSliceTableTest$'
+        let got = s:funcs.construct_function_unique_testname()
+        Assert Equals(got, want)
+    End
+End
+
+Describe s:list_function_names
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+
+        new testdata/sample_test.go
+    End
+
+    After
+        close!
+    End
+
+    It lists all function names when it is inside of some function
+        normal! 22G
+        let want = ['TestWithSliceTableTest', 'TestWithDirectSubtest']
+        let got = s:funcs.list_function_names()
+        Assert Equals(got, want)
+    End
+End
+
+Describe s:construct_run_values
+    Before
+        let s:scope = themis#helper('scope')
+        let s:funcs = s:scope.funcs('/plugin/delve.vim')
+    End
+
+    After
+    End
+
+    It constructs run values when the number of function are several.
+        let arg = ['TestWithSliceTableTest', 'TestWithDirectSubtest']
+        let want = '"(TestWithSliceTableTest|TestWithDirectSubtest)"'
+        let got = s:funcs.construct_run_values(arg)
+        Assert Equals(got, want)
+    End
+    It construct run values when the number of function is only one
+        let arg = ['TestWithDirectSubtest']
+        let want = 'TestWithDirectSubtest'
+        let got = s:funcs.construct_run_values(arg)
+        Assert Equals(got, want)
+    End
+End

--- a/test/testdata/sample_test.go
+++ b/test/testdata/sample_test.go
@@ -1,0 +1,68 @@
+package sample_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWithSliceTableTest(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     []string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "ok",
+			arg:     []string{},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "success",
+			arg:     []string{},
+			want:    0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Process(tt.arg)
+			if gotErr := (err != nil); gotErr != tt.wantErr {
+				t.Fatalf("error differs. want: %t, got: %t", tt.wantErr, gotErr)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("result differs(-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+func TestWithDirectSubtest(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		arg := []string{}
+		want := 0
+		wantErr := false
+
+		got, err := Process(arg)
+		if gotErr := (err != nil); gotErr != wantErr {
+			t.Fatalf("error differs. want: %t, got: %t", wantErr, gotErr)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("result differs(-want/+got)\n%s", diff)
+		}
+	})
+	t.Run("success", func(t *testing.T) {
+		arg := []string{}
+		want := 0
+		wantErr := false
+
+		got, err := Process(arg)
+		if gotErr := (err != nil); gotErr != wantErr {
+			t.Fatalf("error differs. want: %t, got: %t", wantErr, gotErr)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("result differs(-want/+got)\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
- Add .gitignore to ignore test coverage files
- Add Makefile with test and coverage generation targets
- Modify delve.vim to support running tests for current file and function
- Add test configuration files (.coveragerc, .themisrc)
- Add unit tests for new functions in delve.vim
- Add sample test file for testing new functionality